### PR TITLE
Allow for custom device name passed as command line argument

### DIFF
--- a/amsatdisplay.c
+++ b/amsatdisplay.c
@@ -7,6 +7,7 @@
  * */
 
 #include "amsatdisplay.h"
+#include <stdio.h>
 
 // cleans white spaces from beginning, middle and end of a string
 char *cleanString(char *str, int cleanspace)
@@ -167,7 +168,7 @@ void sighandler(int signum)
     exit(0);
 }
 
-int main()
+int main(int argc, char *argv[])
 {
 char s[MAXDATALEN];
 char dispdata[MAXDATALEN];
@@ -179,6 +180,11 @@ uint8_t alldata[MAXDATALEN * FIFO_BUFFER_LENGTH];
     
     // look for the apache HTML path
     searchHTMLpath();
+
+    // Look for command line arguments
+    if( argc == 2 ) {
+        printf("Serial port supplied. Using %s\n", argv[1]);
+    }
     
     // Install or Update the html files
     installHTMLfiles();
@@ -204,7 +210,7 @@ uint8_t alldata[MAXDATALEN * FIFO_BUFFER_LENGTH];
     init_upconv();
     init_downtime();
     init_udppipe();
-    serial_init();
+    serial_init(argv[1]);
     
     while(1)
     {

--- a/amsatdisplay.h
+++ b/amsatdisplay.h
@@ -64,7 +64,7 @@ typedef struct {
     char data[YSIZE][XSIZE_PAC];// 32x8 display (256x64 pixel, each character is 8x8)
 } PAC;
 
-int serial_init();
+int serial_init(char *d);
 void eval_downconverter(char *s);
 void init_udppipe();
 char write_udppipe(unsigned char *data, int len);

--- a/serial.c
+++ b/serial.c
@@ -34,15 +34,19 @@ int rxidx = 0;
 // creates a thread to run all serial specific jobs
 // call this once after program start
 // returns 0=failed, 1=ok
-int serial_init()
+int serial_init(char *d)
 {
-    char *p = get_serial_device_name();
-    if(p == NULL)
-    {
-        printf("no serial device found\n");
-        exit(0);
+    if (d != NULL) {
+        strcpy(serdevice,d);
+    } else {
+        char *p = get_serial_device_name();
+        if(p == NULL)
+        {
+            printf("no serial device found\n");
+            exit(0);
+        }
+        strcpy(serdevice,p);
     }
-    strcpy(serdevice,p);
     
     // automatically choose an USB port
     // start a new process


### PR DESCRIPTION
This patch enables the code to optionally take a device name as command line argument. On a Raspberry Pi you can use /dev/ttyAMA0 as the GPIO UART as input for example. This saves the need for an (external) USB-RS232 adapter.
If no command line argument is given the code behaves as before and scans for a FTDI device with given serial.